### PR TITLE
A couple of minor fixes

### DIFF
--- a/wholegames-comparison.Rmd
+++ b/wholegames-comparison.Rmd
@@ -27,7 +27,7 @@ In all cases having HTTP tests, i.e. tests that work independently from any inte
 
 The difference between packages, the _test writing experience_ depends on how you can provide responses from the API, both real ones and fake ones.
 
-With vcr and httptest for tests testing _normal behavior_, after set up (for which there is a helper function), testing is just a function away (`vcr::use_cassette()`, `httptest::with_mock_dir()`).
+With vcr and httptest for tests testing _normal behavior_, after set up (for which there is a helper function), testing is just a function away (`vcr::use_cassette()`, `httptest::with_mock_dir()`, `httptest::with_mock_api()`).
 Recording happens automatically during the first run of tests.
 You might also provide fake recorded response or dumb down the existing ones.
 For creating _API errors_, and API sequence of responses (e.g. 502 then 200), you end up either using webmockr, or amending mock files, see [vcr](https://docs.ropensci.org/vcr/articles/cassette-manual-editing.html) and httptest related docs.[^seq-httptest]

--- a/wholegames-httptest.Rmd
+++ b/wholegames-httptest.Rmd
@@ -110,6 +110,12 @@ Without the HTTP testing infrastructure, testing for behavior of the package in 
 
 Regarding our secret API token, since httptest doesn't save the requests, and since the responses don't contain the token, it is safe without our making any effort.
 
+::: {.alert .alert-dismissible .alert-primary}
+In this demo we used `httptest::with_mock_dir()` but there are other ways to use httptest, e.g. using `httptest::with_mock_api()` that does not require naming a directory (you'd still need to use a separate directory for mocking the error response).
+ 
+Find our more in the [main httptest vignette](https://enpiar.com/r/httptest/articles/httptest.html), especially if you don't find the `httptest::with_mock_dir()` approach enjoyable.
+:::
+
 ## Also testing for real interactions {#httptest-real}
 
 What if the API responses change?

--- a/wholegames-httptest.Rmd
+++ b/wholegames-httptest.Rmd
@@ -113,7 +113,7 @@ Regarding our secret API token, since httptest doesn't save the requests, and si
 ::: {.alert .alert-dismissible .alert-primary}
 In this demo we used `httptest::with_mock_dir()` but there are other ways to use httptest, e.g. using `httptest::with_mock_api()` that does not require naming a directory (you'd still need to use a separate directory for mocking the error response).
  
-Find our more in the [main httptest vignette](https://enpiar.com/r/httptest/articles/httptest.html), especially if you don't find the `httptest::with_mock_dir()` approach enjoyable.
+Find out more in the [main httptest vignette](https://enpiar.com/r/httptest/articles/httptest.html).
 :::
 
 ## Also testing for real interactions {#httptest-real}

--- a/wholegames-httptest.Rmd
+++ b/wholegames-httptest.Rmd
@@ -45,7 +45,7 @@ So this was just setup, now on to adapting our tests!
 
 ## Actual testing
 
-The key function will be `httptest::with_mock_dir("dir", {code-block})` which tells vcr to create mock files under `tests/testthat/dir` to store all API responses for API calls occurring in the code block. 
+The key function will be `httptest::with_mock_dir("dir", {code-block})` which tells httptest to create mock files under `tests/testthat/dir` to store all API responses for API calls occurring in the code block. 
 We are allowed to tweak the mock files by hand, and we will do that in some cases.
 
 Let's tweak the test file for `gh_status_api`, it becomes
@@ -81,8 +81,8 @@ The test file ` tests/testthat/test-organizations.R` is now:
 
 ```r
 with_mock_dir("gh_organizations", {
-test_that("gh_organizations works", {
-  testthat::expect_type(gh_organizations(), "character")
+  test_that("gh_organizations works", {
+    testthat::expect_type(gh_organizations(), "character")
   })
 })
 
@@ -121,7 +121,7 @@ As with vcr we setup a [GitHub Actions workflow](https://github.com/maelle/exemp
 The difference is what and where these tests are.
 As some tests with custom made mock files can be more specific (e.g. testing for actual values, whereas the latest responses from the API will have different values), instead of turning off mock files usage, we use our old original tests that we put in a folder called `real-tests`.
 Most of the time `real-tests` is .Rbuildignored but in the scheduled run, before checking the package we replace the content of `tests` with `real-tests`.
-An alternative would be to use `testthat::test_dir()` on that directory but in case of failures we would not get artefacts as we do with `R CMD check` (at least not without further effort).
+An alternative would be to use `testthat::test_dir()` on that directory but in case of failures we would not get artifacts as we do with `R CMD check` (at least not without further effort).
 
 Again, one could imagine other strategies, but in all cases it is important to keep checking the package against the real web service fairly regularly.
 


### PR DESCRIPTION
This is nice and clear, particularly in the context of the other chapters in the book. 

Would it make sense to link to the [main httptest vignette](https://enpiar.com/r/httptest/articles/httptest.html) somewhere? It goes deeper on some of these topics, and it describes an alternative workflow for writing tests (which admittedly is less intuitive than the one you present here, but it shows some other useful testing functionality).