### PR TITLE
in date, "built on" is already in the book template

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -1,6 +1,6 @@
 --- 
 title: "HTTP testing in R"
-date: "`r paste0('built on ', Sys.Date())`"
+date: "`r Sys.Date()`"
 author: "Scott Chamberlain, Maëlle Salmon"
 site: bookdown::bookdown_site
 documentclass: book


### PR DESCRIPTION
It is currently duplicated: 
![image](https://user-images.githubusercontent.com/6791940/110778911-3d7e6980-8263-11eb-8974-9a2cef12eb93.png)

https://books.ropensci.org/http-testing/index.html
